### PR TITLE
Revert "Fix Syntax $input"

### DIFF
--- a/README.md
+++ b/README.md
@@ -13,71 +13,69 @@ print $xml->buildXML($input);
 </code></pre>
 
 INPUT:
-<pre><code>
-$input = array(
-    'product' => array(
-        '@id' => 7,
-        'name' => 'some string',
-        'seo' => 'some-string',
-        'ean' => '',
-        'producer' => array(
-            'name' => null,
-            'photo' => '1.png'
-        ),
-        'stock' => 123,
-        'trackstock' => 0,
-        'new' => 0,
-        'pricewithoutvat' => 1111,
-        'price' => 1366.53,
-        'discountpricenetto' => null,
-        'discountprice' => null,
-        'vatvalue' => 23,
-        'currencysymbol' => 'PLN',
-        '#description' => '',
-        '#longdescription' => '',
-        '#shortdescription' => '',
-        'category' => array(
-            'photo' => '1.png',
-            'name' => 'test3',
-        ),
-        'staticattributes' => array(
-            'attributegroup' => array(
-                1 => array(
-                    '@name' => 'attributes group',
-                    'attribute' => array(
-                        0 => array(
-                            'name' => 'second',
-                            'description' => '<p>desc2</p>',
-                            'file' => '',
-                        ),
-                        1 => array (
-                            'name' => 'third',
-                            'description' => '<p>desc3</p>',
-                            'file' => '',
-                        ),
-                    )
-                )
-            )
-        ),
-        'attributes' => array(),
-        'photos' => array(
-            'photo' => array(
-                0 => array(
-                    '@mainphoto' => '1',
-                    '%' => '1.png',
-                ),
-                1 => array(
-                    '@mainphoto' => '0',
-                    '%' => '2.png',
-                ),
-                2 => array(
-                    '@mainphoto' => '0',
-                    '%' => '3.png',
-                )
-            )
-        )
-    )
-);
+<pre><code>$input = array('product' => array(
+      '@id' => 7,
+      'name' => 'some string',
+      'seo' => 'some-string',
+      'ean' => '',
+      'producer' => array(
+          'name' => null,
+          'photo' => '1.png'
+      )
+      'stock' => 123,
+      'trackstock' => 0,
+      'new' => 0,
+      'pricewithoutvat' => 1111,
+      'price' => 1366.53,
+      'discountpricenetto' => null,
+      'discountprice' => null,
+      'vatvalue' => 23,
+      'currencysymbol' => 'PLN',
+      '#description' => '',
+      '#longdescription' => '',
+      '#shortdescription' => '',
+      'category' => array(
+          'photo' => '1.png',
+          'name' => 'test3',
+      )
+      'staticattributes' => array(
+          'attributegroup' => array(
+              1 => array(
+                  '@name' => 'attributes group',
+                  'attribute' => array(
+                      0 => array(
+                          'name' => 'second',
+                          'description' => '&lt;p&gt;desc2&lt;/p&gt;',
+                          'file' => '',
+                      ),
+                      1 => 
+                        array
+                          'name' => 'third',
+                          'description' => '&lt;p&gt;desc3&lt;/p&gt;',
+                          'file' => '',
+                      ),
+                  )
+              )
+          )
+      ),
+      'attributes' => array(),
+      'photos' => array(
+          'photo' => array(
+              0 => array(
+                  '@mainphoto' => '1',
+                  '%' => '1.png',
+              ),
+              1 => array(
+                  '@mainphoto' => '0',
+                  '%' => '2.png',
+              ),
+              2 => array(
+                  '@mainphoto' => '0',
+                  '%' => '3.png',
+              )
+          )
+      )
+));
 </code></pre>
 
 OUTPUT (XML data):


### PR DESCRIPTION
Reverts jmarceli/array2xml#1. It screws the README.md markup because of direct `<p>` tags which are not escaped.